### PR TITLE
Trim zero scale type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/sqlite",
-      "version": "2.6.6",
+      "version": "2.6.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^2.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/sqlite",
-      "version": "2.6.5",
+      "version": "2.6.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "MOST Web Framework SQLite Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "MOST Web Framework SQLite Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/SqliteAdapter.js
+++ b/src/SqliteAdapter.js
@@ -8,6 +8,7 @@ import { SqliteFormatter } from './SqliteFormatter';
 import sqlite from 'sqlite3';
 const sqlite3 = sqlite.verbose();
 const SqlDateRegEx = /^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d+\+[0-1][0-9]:[0-5][0-9]$/;
+
 /**
  * @class
  * @augments DataAdapter
@@ -457,7 +458,18 @@ class SqliteAdapter {
                                 }
                                 else {
                                     newType = format('%t', x);
-                                    oldType = column.type.toUpperCase().concat(column.nullable ? ' NOT NULL' : ' NULL');
+                                    oldType = column.type.toUpperCase().concat(column.nullable ? ' NULL' : ' NOT NULL');
+                                    // trim zero scale for both new and old type
+                                    // e.g. TEXT(50,0) to TEXT(50)
+                                    const reTrimScale = /^(NUMERIC|TEXT|INTEGER)\((\d+)(,0)\)/g;
+                                    if (reTrimScale.test(newType) === true) {
+                                        // trim
+                                        newType = newType.replace(reTrimScale, '$1($2)');
+                                    }
+                                    if (reTrimScale.test(oldType) === true) {
+                                        // trim
+                                        oldType = oldType.replace(reTrimScale, '$1($2)');
+                                    }
                                     if (newType === oldType) {
                                         //remove column from add collection
                                         migration.add.splice(i, 1);


### PR DESCRIPTION
This PR trims zero scale while comparing types e.g. TEXT(100,0) => TEXT(100). This operation allows migration process to ignore such changes.