### PR TITLE
Escape substr parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/sqlite",
-      "version": "2.6.8",
+      "version": "2.6.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "description": "MOST Web Framework SQLite Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/SqliteFormatter.js
+++ b/src/SqliteFormatter.js
@@ -147,10 +147,11 @@ class SqliteFormatter extends SqlFormatter {
      * @returns {string}
      */
     $substring(p0, pos, length) {
-        if (length)
-            return sprintf('SUBSTR(%s,%s,%s)', this.escape(p0), pos.valueOf() + 1, length.valueOf());
-        else
-            return sprintf('SUBSTR(%s,%s)', this.escape(p0), pos.valueOf() + 1);
+        if (length) {
+            return sprintf('SUBSTR(%s,%s + 1,%s)', this.escape(p0), this.escape(pos), this.escape(length));
+        } else {
+            return sprintf('SUBSTR(%s,%s + 1)', this.escape(p0), this.escape(pos));
+        }
     }
     /**
      * Implements substring(str,pos) expression formatter.
@@ -160,10 +161,11 @@ class SqliteFormatter extends SqlFormatter {
      * @returns {string}
      */
     $substr(p0, pos, length) {
-        if (length)
-            return sprintf('SUBSTR(%s,%s,%s)', this.escape(p0), pos.valueOf() + 1, length.valueOf());
-        else
-            return sprintf('SUBSTR(%s,%s)', this.escape(p0), pos.valueOf() + 1);
+        if (length) {
+            return sprintf('SUBSTR(%s,%s + 1,%s)', this.escape(p0), this.escape(pos), this.escape(length));
+        } else {
+            return sprintf('SUBSTR(%s,%s + 1)', this.escape(p0), this.escape(pos));
+        }
     }
     /**
      * Implements length(a) expression formatter.


### PR DESCRIPTION
This PR updates `$substr()` dialect to escape all its parameters. 