### PR TITLE
Use more than 2 arguments in concat method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/sqlite",
-      "version": "2.6.9",
+      "version": "2.6.11",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "description": "MOST Web Framework SQLite Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/spec/StringFunctions.spec.js
+++ b/spec/StringFunctions.spec.js
@@ -1,3 +1,4 @@
+import { QueryField } from '@themost/query';
 import { TestApplication } from './TestApplication';
 
 describe('StringFunctions', () => {
@@ -34,6 +35,25 @@ describe('StringFunctions', () => {
         await app.executeInTestTranscaction(async (context) => {
             let items = await context.model('Product')
                 .asQueryable().where('name').startsWith('Apple').equal(true).getItems();
+            expect(items).toBeInstanceOf(Array);
+            for (const item of items) {
+                expect(item.name.startsWith('Apple')).toBeTruthy();
+            }
+        });
+    });
+
+    it('should use concat()', async () => {
+        await app.executeInTestTranscaction(async (context) => {
+            let items = await context.model('Product')
+                .select(new QueryField('id'), new QueryField({
+                    name: {
+                        $concat: [
+                            new QueryField('name'),
+                            '-',
+                            new QueryField('model')
+                        ]
+                    }
+                })).where('name').startsWith('Apple').equal(true).getItems();
             expect(items).toBeInstanceOf(Array);
             for (const item of items) {
                 expect(item.name.startsWith('Apple')).toBeTruthy();

--- a/src/SqliteFormatter.js
+++ b/src/SqliteFormatter.js
@@ -136,8 +136,18 @@ class SqliteFormatter extends SqlFormatter {
      * @param {*} p1
      * @returns {string}
      */
+    // eslint-disable-next-line no-unused-vars
     $concat(p0, p1) {
-        return sprintf('(IFNULL(%s,\'\') || IFNULL(%s,\'\'))', this.escape(p0), this.escape(p1));
+        const args = Array.from(arguments);
+        if (args.length < 2) {
+            throw new Error('Concat method expects two or more arguments');
+        }
+        let result = '(';
+        result += Array.from(args).map((arg) => {
+            return `IFNULL(${this.escape(arg)},\'\')`
+        }).join(' || ');
+        result += ')';
+        return result;
     }
     /**
      * Implements substring(str,pos) expression formatter.


### PR DESCRIPTION
This PR enables the usage of more 2 arguments in $concat() method