### PR TITLE
Support full table migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.12",
+  "version": "2.6.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/sqlite",
-      "version": "2.6.12",
+      "version": "2.6.13",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^2.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3698,9 +3698,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "optional": true
     },
     "node_modules/http-proxy-agent": {
@@ -4160,9 +4160,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -5365,9 +5365,9 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "node_modules/sqlite3": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.8.tgz",
-      "integrity": "sha512-f2ACsbSyb2D1qFFcqIXPfFscLtPVOWJr5GmUzYxf4W+0qelu5MWrR+FAQE1d5IUArEltBrzSDxDORG8P/IkqyQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.6.tgz",
+      "integrity": "sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -8586,9 +8586,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "optional": true
     },
     "http-proxy-agent": {
@@ -8952,9 +8952,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "kind-of": {
@@ -9840,9 +9840,9 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "sqlite3": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.8.tgz",
-      "integrity": "sha512-f2ACsbSyb2D1qFFcqIXPfFscLtPVOWJr5GmUzYxf4W+0qelu5MWrR+FAQE1d5IUArEltBrzSDxDORG8P/IkqyQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.6.tgz",
+      "integrity": "sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "node-addon-api": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.12",
+  "version": "2.6.13",
   "description": "MOST Web Framework SQLite Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/spec/SqliteAdapter.migrate.spec.js
+++ b/spec/SqliteAdapter.migrate.spec.js
@@ -1,0 +1,69 @@
+import { DataConfigurationStrategy } from '@themost/data';
+import { TestApplication } from './TestApplication';
+
+describe('SqliteAdapter.migrate', () => {
+    /**
+     * @type {TestApplication}
+     */
+    let app;
+    beforeAll(async () => {
+        app = new TestApplication(__dirname);
+    });
+    beforeEach(async () => {
+        //
+    });
+    afterAll(async () => {
+        await app.finalize();
+    });
+    afterEach(async () => {
+        //
+    });
+    
+    it('should migrate table and change column size', async () => {
+        await app.executeInTestTranscaction(async (context) => {
+            const service = app.configuration.getStrategy(DataConfigurationStrategy);
+            const modelDefinition = service.getModelDefinition('VisitorActivity');
+            modelDefinition.fields.find((x) => x.name === 'visitorBrowser').size = 36;
+            modelDefinition.version = '3.0.0';
+            service.setModelDefinition('VisitorActivity', modelDefinition);
+            delete app.configuration.cache;
+            let columns = await context.db.table('VisitorActivityBase').columnsAsync();
+            let column = columns.find((x) => x.name === 'visitorBrowser');
+            expect(column).toBeTruthy();
+            expect(column.size).toBeFalsy();
+            const count = await context.model('VisitorActivity').asQueryable().silent().count();
+            await context.model('VisitorActivity').migrateAsync();
+            columns = await context.db.table('VisitorActivityBase').columnsAsync();
+            column = columns.find((x) => x.name === 'visitorBrowser');
+            expect(column).toBeTruthy();
+            expect(column.size).toEqual(36);
+            const newCount = await context.model('VisitorActivity').asQueryable().silent().count();
+            expect(newCount).toBeTruthy();
+            expect(newCount).toEqual(count);
+        });
+    });
+
+    it('should migrate table and remove column', async () => {
+        await app.executeInTestTranscaction(async (context) => {
+            const service = app.configuration.getStrategy(DataConfigurationStrategy);
+            const modelDefinition = service.getModelDefinition('VisitorActivity');
+            const findIndex = modelDefinition.fields.findIndex((x) => x.name === 'visitor');
+            modelDefinition.fields.splice(findIndex, 1);
+            modelDefinition.version = '3.0.0';
+            service.setModelDefinition('VisitorActivity', modelDefinition);
+            delete app.configuration.cache;
+            let columns = await context.db.table('VisitorActivityBase').columnsAsync();
+            let column = columns.find((x) => x.name === 'visitor');
+            expect(column).toBeTruthy();
+            const count = await context.model('VisitorActivity').asQueryable().silent().count();
+            await context.model('VisitorActivity').migrateAsync();
+            columns = await context.db.table('VisitorActivityBase').columnsAsync();
+            column = columns.find((x) => x.name === 'visitor');
+            expect(column).toBeFalsy();
+            const newCount = await context.model('VisitorActivity').asQueryable().silent().count();
+            expect(newCount).toBeTruthy();
+            expect(newCount).toEqual(count);
+        });
+    });
+
+});

--- a/spec/TestApplication.js
+++ b/spec/TestApplication.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line no-unused-vars
-import {DataApplication, DataConfigurationStrategy, NamedDataContext, DataCacheStrategy, DataContext, ODataModelBuilder, ODataConventionModelBuilder} from '@themost/data';
-import { createInstance, SqliteAdapter } from '../src';
-import path from 'path';
+import {DataApplication, DataConfigurationStrategy, DataCacheStrategy, DataContext} from '@themost/data';
+import { createInstance } from '../src';
 
 const testConnectionOptions = {
     'database': 'spec/db/local.db'

--- a/spec/helpers/reporter.js
+++ b/spec/helpers/reporter.js
@@ -1,6 +1,5 @@
 const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 
-jasmine.getEnv().clearReporters();               // remove default reporter logs
 // noinspection JSCheckFunctionSignatures
 jasmine.getEnv().addReporter(new SpecReporter({  // add jasmine-spec-reporter
     spec: {

--- a/src/SqliteAdapter.js
+++ b/src/SqliteAdapter.js
@@ -470,7 +470,46 @@ class SqliteAdapter {
                             }
                         }
                         if (forceAlter) {
-                            return cb(new Error('Full table migration is not yet implemented.'));
+                            // eslint-disable-next-line no-unexpected-multiline
+                            return (async function() {
+                                // prepare to rename existing table and create a new one
+                                const renamed = '__' + migration.appliesTo + '_' + migration.appliesTo + '__';
+                                const formatter = new SqliteFormatter();
+                                const renameTable = formatter.escapeName(renamed);
+                                const table = formatter.escapeName(migration.appliesTo);
+                                // rename table
+                                await self.executeAsync(`ALTER TABLE {table} RENAME TO ${renameTable}`);
+                                // format field collection
+                                let fields = migration.add.filter((x) => {
+                                    return !x.oneToMany;
+                                }).map((x) => {
+                                    return format('"%f" %t', x);
+                                }).join(', ');
+                                let sql = `CREATE TABLE ${table} (${fields})`;
+                                // create table
+                                await self.executeAsync(sql);
+                                // get source fields
+                                const existingFields = await self.table(renamed).columnsAsync();
+                                const newFields = await self.table(migration.appliesTo).columnsAsync();
+                                const insertFields = [];
+                                for (const existingField of existingFields) {
+                                    const insertField = newFields.find((x) => x.name === existingField.name);
+                                    if (insertField != null) {
+                                        insertFields.push(insertField);
+                                    }
+                                }
+                                if (insertFields.length === 0) {
+                                    throw new Error('Table migration cannot be completed because the collection of fields is empty.');
+                                }
+                                fields = insertFields.map((x) => formatter.escapeName(x.name)).join(', ');
+                                sql = `INSERT INTO ${table}(${fields}) SELECT ${fields} FROM ${renameTable}`;
+                                // insert data
+                                await self.executeAsync(sql);
+                            })().then(() => {
+                                return cb(null, 1);
+                            }).catch((error) => {
+                                return cb(error);
+                            });
                         }
                         else {
                             const formatter = new SqliteFormatter();

--- a/src/SqliteAdapter.js
+++ b/src/SqliteAdapter.js
@@ -487,7 +487,7 @@ class SqliteAdapter {
                             // eslint-disable-next-line no-unexpected-multiline
                             return (async function() {
                                 // prepare to rename existing table and create a new one
-                                const renamed = '__' + migration.appliesTo + '_' + migration.appliesTo + '__';
+                                const renamed = '__' + migration.appliesTo + '_' + new Date().getTime().toString() + '__';
                                 const formatter = new SqliteFormatter();
                                 const renameTable = formatter.escapeName(renamed);
                                 const table = formatter.escapeName(migration.appliesTo);


### PR DESCRIPTION
This PR enables the support of SQLite full table migration while changing or removing fields. This operation -of changing an existing column- which is not supported by SQLite is being completed by renaming source table, creating a new one and finally move data from source to newly created table.