### PR TITLE
do not remove null values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.14",
+  "version": "2.6.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/sqlite",
-      "version": "2.6.14",
+      "version": "2.6.15",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.6.14",
+  "version": "2.6.15",
   "description": "MOST Web Framework SQLite Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/SqliteAdapter.js
+++ b/src/SqliteAdapter.js
@@ -1069,11 +1069,9 @@ class SqliteAdapter {
                                             result.forEach(function (x) {
                                                 keys.forEach(function (y) {
                                                     const value = x[y];
-                                                    if (value === null) {
-                                                        delete x[y];
-                                                    } else if (typeof value === 'string' && SqlDateRegEx.test(value)) {
+                                                    if (typeof value === 'string' && SqlDateRegEx.test(value)) {
                                                         x[y] = new Date(value);
-                                                    } 
+                                                    }
                                                 });
                                             });
                                         }
@@ -1082,9 +1080,7 @@ class SqliteAdapter {
                                         keys = Object.keys(result);
                                         keys.forEach(function (y) {
                                             const value = result[y];
-                                            if (value === null) {
-                                                delete result[y];
-                                            } else if (typeof value === 'string' && SqlDateRegEx.test(value)) {
+                                            if (typeof value === 'string' && SqlDateRegEx.test(value)) {
                                                 result[y] = new Date(value);
                                             } 
                                         });


### PR DESCRIPTION
This PR disables the removal of null values returned by `SqliteAdapter.execute()`