### PR TITLE
use SQLITE_BUSY error and retry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/sqlite",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "MOST Web Framework SQLite Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR handles SQLITE_BUSY error and forces query execution retry based on configurable properties defined at adapter settings.

```json
{ 
        "name":"local-db", "invariantName":"sqlite", "default":true,
        "options": {
            "database":"db/local.db",
            "retry": 4,
            "retryInterval": 1000
        }
    }
```

where `retry` defines the number of attempts before throwing SQLITE_BUSY exception and `retryInterval` the number of milliseconds to wait before next attempt. The defaults values are `retry=4` and `retryInterval=1000`.


