### PR TITLE
use x86 for macos x64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/sqlite",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "MOST Web Framework SQLite Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/postinstall.js
+++ b/postinstall.js
@@ -5,7 +5,22 @@ const path = require('path');
 const { promisify } = require('util');
 const packageJson = require('./package.json');
 const unzipper = require('unzipper');
-const mkdirAsync = promisify(fs.mkdir);
+
+function mkdirAsync(dir) {
+    return new Promise((resolve, reject) => {
+        void fs.stat(dir, function (err, stats) {
+            if (err && err.code !== 'ENOENT') {
+                return reject(err);
+            }
+            void fs.mkdir(dir, { recursive: true }, function (err) {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve();
+            });
+        })
+    });
+}
 
 function downloadAsync(url, dest) {
     return new Promise((resolve, reject) => {
@@ -52,6 +67,7 @@ function unzipAsync(zipFile, dest) {
             break;
         case 'darwin':
             platform = 'macos';
+            arch = arch === 'x64' ? 'x86' : arch;
             break;
         case 'linux':
             platform = 'linux';


### PR DESCRIPTION
This PR updates postinstall script for using `x86` sqlean release for macos `x64`.