### PR TITLE
implement SqliteAdapter.logger

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,21 @@
 require('dotenv').config();
 const { JsonLogger } = require('@themost/json-logger');
 const { TraceUtils } = require('@themost/common');
+
+if (typeof JsonLogger.prototype.setLogLevel !== 'function') {
+    Object.assign(JsonLogger.prototype, {
+        /**
+         * @param {string} level
+         */
+        setLogLevel(level) {
+            const logLevel = [ 'error', 'warn', 'info', 'verbose', 'debug' ].indexOf(level);
+            if (logLevel > -1) {
+                this.level = logLevel;
+            }
+        }
+    })
+}
+
 process.env.NODE_ENV = 'development';
 TraceUtils.useLogger(new JsonLogger({
     format: 'raw'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.9.3",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/sqlite",
-      "version": "2.9.3",
+      "version": "2.10.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.9.3",
+  "version": "2.10.0",
   "description": "MOST Web Framework SQLite Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/spec/TestApplication.js
+++ b/spec/TestApplication.js
@@ -3,7 +3,8 @@ import {DataApplication, DataConfigurationStrategy, DataCacheStrategy, DataConte
 import { createInstance } from '../src';
 
 const testConnectionOptions = {
-    'database': 'spec/db/local.db'
+    'database': 'spec/db/local.db',
+    'logLevel': 'debug'
 };
 
 

--- a/src/SqliteAdapter.d.ts
+++ b/src/SqliteAdapter.d.ts
@@ -1,6 +1,6 @@
 
 // MOST Web Framework Codename Zero Gravity Copyright (c) 2017-2022, THEMOST LP
-import { DataAdapterBase, DataAdapterIndexes, DataAdapterMigration, DataAdapterTable, DataAdapterView } from '@themost/common';
+import { DataAdapterBase, DataAdapterIndexes, DataAdapterMigration, DataAdapterTable, DataAdapterView, TraceLogger } from '@themost/common';
 import { QueryExpression, SqlFormatter } from '@themost/query';
 import {AsyncSeriesEventEmitter} from '@themost/events';
 
@@ -8,7 +8,9 @@ export declare class SqliteAdapter implements DataAdapterBase {
     executing: AsyncSeriesEventEmitter<{target: SqliteAdapter, query: (string|QueryExpression), params?: unknown[]}>;
     executed: AsyncSeriesEventEmitter<{target: SqliteAdapter, query: (string|QueryExpression), params?: unknown[], results: uknown[]}>;
 
-    constructor(options: { database: string, extensions?: { [key: string]: string }, retry?: number, retryInterval?: number });
+    logger: TraceLogger;
+
+    constructor(options: { database: string, extensions?: { [key: string]: string }, retry?: number, retryInterval?: number, logLevel?: 'error' | 'warn' | 'info' |  'verbose' | 'debug' });
     rawConnection?: any;
     options?: { database: string, extensions?: { [key: string]: string }, retry?: number, retryInterval?: number };
     selectIdentityAsync(entity: string, attribute: string): Promise<any>;

--- a/src/SqliteAdapter.js
+++ b/src/SqliteAdapter.js
@@ -104,13 +104,17 @@ class SqliteAdapter {
 
         this.executed.subscribe(onReceivingJsonObject);
         /**
+         * create a new instance of logger
          * @type {import('@themost/common').TraceLogger}
          */
         this.logger = createLogger();
-        // stage 2: use log level from connection options, if any
+        // use log level from connection options, if any
         if (typeof this.options.logLevel === 'string' && this.options.logLevel.length) {
+            // if the logger has level(string) function
             if (typeof this.logger.level === 'function') {
+                // try to set log level
                 this.logger.level(this.options.logLevel);
+            // otherwise, check if logger has setLogLevel(string) function
             } else if (typeof this.logger.setLogLevel === 'function') {
                 this.logger.setLogLevel(this.options.logLevel);
             }


### PR DESCRIPTION
This PR implements `SqliteAdapter.logger` for using a new instance of `TraceLogger` inside adapter. The log level of this logger can be customized by defining `logLevel` option at connect options;

```javascript
const db = new SqliteAdapter({
    database: 'db/local.db',
   logLevel: 'debug'
});
```