### PR TITLE
implement tables and views list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/sqlite",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/sqlite",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "MOST Web Framework SQLite Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/spec/SqliteAdapter.spec.js
+++ b/spec/SqliteAdapter.spec.js
@@ -27,6 +27,26 @@ describe('SqliteAdapter', () => {
         });
     });
 
+    it('should get tables', async () => {
+        await app.executeInTestTranscaction(async (context) => {
+            const tables = await context.db.tables().listAsync();
+            expect(Array.isArray(tables)).toBeTruthy();
+            expect(tables.length).toBeGreaterThan(0);
+            const table1 = tables.find((table) => table.name === 'UserBase');
+            expect(table1).toBeTruthy();
+        });
+    });
+
+    it('should get views', async () => {
+        await app.executeInTestTranscaction(async (context) => {
+            const views = await context.db.views().listAsync();
+            expect(Array.isArray(views)).toBeTruthy();
+            expect(views.length).toBeGreaterThan(0);
+            const view1 = views.find((table) => table.name === 'UserData');
+            expect(view1).toBeTruthy();
+        });
+    });
+
     it('should create table', async () => {
         await app.executeInTestTranscaction(async (context) => {
             const db = context.db;

--- a/src/SqliteAdapter.d.ts
+++ b/src/SqliteAdapter.d.ts
@@ -4,6 +4,16 @@ import { DataAdapterBase, DataAdapterIndexes, DataAdapterMigration, DataAdapterT
 import { QueryExpression, SqlFormatter } from '@themost/query';
 import {AsyncSeriesEventEmitter} from '@themost/events';
 
+export declare interface DataAdapterTables {
+    list(callback: (err: Error, result: { name: string }[]) => void): void;
+    listAsync(): Promise<{ name: string }[]>;
+}
+
+export declare interface DataAdapterViews {
+    list(callback: (err: Error, result: { name: string }[]) => void): void;
+    listAsync(): Promise<{ name: string }[]>;
+}
+
 export declare class SqliteAdapter implements DataAdapterBase {
     executing: AsyncSeriesEventEmitter<{target: SqliteAdapter, query: (string|QueryExpression), params?: unknown[]}>;
     executed: AsyncSeriesEventEmitter<{target: SqliteAdapter, query: (string|QueryExpression), params?: unknown[], results: uknown[]}>;
@@ -32,7 +42,9 @@ export declare class SqliteAdapter implements DataAdapterBase {
     lastIdentity(callback: (err: Error, value: any) => void): void;
     lastIdentityAsync(): Promise<any>;
     table(table: string): DataAdapterTable;
+    tables(): DataAdapterTables;
     view(view: string): DataAdapterView;
+    views(): DataAdapterViews;
     indexes(table: string): DataAdapterIndexes;
     getFormatter(): SqlFormatter;
 }

--- a/src/SqliteAdapter.js
+++ b/src/SqliteAdapter.js
@@ -1120,6 +1120,70 @@ class SqliteAdapter {
         };
     }
 
+    /**
+     * 
+     * @returns {import('./SqliteAdapter').DataAdapterTables}
+     */
+    tables() {
+        const self = this;
+        return {
+            /**
+             * @param {function} callback
+             * @returns void
+             */
+            list: function(callback) {
+                void self.execute('SELECT name FROM sqlite_master WHERE type=\'table\'', null, (err, results) => {
+                    if (err) {
+                        return callback(err);
+                    }
+                    return callback(null, results);
+                });
+            },
+            listAsync: function() {
+                return new Promise((resolve, reject) => {
+                    this.list((err, value) => {
+                        if (err) {
+                            return reject(err);
+                        }
+                        return resolve(value);
+                    });
+                });
+            }
+        }
+    }
+
+    /**
+     * 
+     * @returns {import('./SqliteAdapter').DataAdapterViews}
+     */
+    views() {
+        const self = this;
+        return {
+            /**
+             * @param {function} callback
+             * @returns void
+             */
+            list: function(callback) {
+                void self.execute('SELECT name FROM sqlite_master WHERE type=\'view\'', null, (err, results) => {
+                    if (err) {
+                        return callback(err);
+                    }
+                    return callback(null, results);
+                });
+            },
+            listAsync: function() {
+                return new Promise((resolve, reject) => {
+                    this.list((err, value) => {
+                        if (err) {
+                            return reject(err);
+                        }
+                        return resolve(value);
+                    });
+                });
+            }
+        }
+    }
+
     @before(({target, args}, callback) => {
         const [query, params] = args;
         void target.executing.emit({


### PR DESCRIPTION
This PR implements `SqliteAdapter.tables()` and `SqliteAdapter.views()` for enumerating tables and views of an sqlite db.

```javascript
const tables = await context.db.tables().listAsync();
```

or

```javascript
const views = await context.db.views().listAsync();
```
