### PR TITLE
resolve __dirname when is not available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/sqlite",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/sqlite",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "rimraf": "^3.0.2",
         "rollup": "^2.73.0",
         "rollup-plugin-dts": "^4.2.1",
+        "rollup-plugin-replace": "^2.2.0",
         "typescript": "^4.6.4",
         "typescript-eslint": "^8.12.1"
       },
@@ -9007,6 +9008,35 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/rollup-plugin-replace": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz",
+      "integrity": "sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==",
+      "deprecated": "This module has moved and is now available at @rollup/plugin-replace. Please update your dependencies. This version is no longer maintained.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.25.2",
+        "rollup-pluginutils": "^2.6.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/sqlite",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "MOST Web Framework SQLite Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.73.0",
     "rollup-plugin-dts": "^4.2.1",
+    "rollup-plugin-replace": "^2.2.0",
     "typescript": "^4.6.4",
     "typescript-eslint": "^8.12.1"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import { babel } from '@rollup/plugin-babel';
 import * as pkg from './package.json';
 import dts from 'rollup-plugin-dts';
+import replace from 'rollup-plugin-replace';
 
 export default [
     {
@@ -23,7 +24,12 @@ export default [
             sourcemap: true
         },
         external: Object.keys(pkg.dependencies).concat(Object.keys(pkg.peerDependencies)),
-        plugins: [babel({ babelHelpers: 'bundled' })]
+        plugins: [
+            replace({
+                '__dirname': 'import.meta?.dirname'
+            }),
+            babel({ babelHelpers: 'bundled' })
+        ]
     },
     {
         input: 'src/index.d.ts',

--- a/src/SqliteExtensions.js
+++ b/src/SqliteExtensions.js
@@ -1,11 +1,9 @@
-import {resolve} from 'path';
-// __dirname is not available in ES modules, so we define it here
-const __dirname = __dirname || import.meta.dirname;
+import path from 'path';
 
 const SqliteExtensions = {
-    uuid: resolve(__dirname, '../lib/uuid'), // Universally Unique Identifiers
-    crypto: resolve(__dirname, '../lib/crypto'), // hashing, encoding and decoding data
-    regexp: resolve(__dirname, '../lib/regexp') // regular expressions
+    uuid: path.resolve(__dirname, '../lib/uuid'), // Universally Unique Identifiers
+    crypto: path.resolve(__dirname, '../lib/crypto'), // hashing, encoding and decoding data
+    regexp: path.resolve(__dirname, '../lib/regexp') // regular expressions
 }
 
 export {

--- a/src/SqliteExtensions.js
+++ b/src/SqliteExtensions.js
@@ -1,9 +1,11 @@
-import path from 'path';
+import {resolve} from 'path';
+// __dirname is not available in ES modules, so we define it here
+const __dirname = __dirname || import.meta.dirname;
 
 const SqliteExtensions = {
-    uuid: path.resolve(__dirname, '../lib/uuid'), // Universally Unique Identifiers
-    crypto: path.resolve(__dirname, '../lib/crypto'), // hashing, encoding and decoding data
-    regexp: path.resolve(__dirname, '../lib/regexp') // regular expressions
+    uuid: resolve(__dirname, '../lib/uuid'), // Universally Unique Identifiers
+    crypto: resolve(__dirname, '../lib/crypto'), // hashing, encoding and decoding data
+    regexp: resolve(__dirname, '../lib/regexp') // regular expressions
 }
 
 export {


### PR DESCRIPTION
This pull request updates the build configuration to improve compatibility with ES modules by replacing usage of `__dirname` and introducing a new plugin dependency. The most important changes are grouped below:

**Build configuration improvements:**

* Updated the Rollup configuration in `rollup.config.js` to use the `rollup-plugin-replace` plugin, replacing all occurrences of `__dirname` with `import.meta?.dirname` to better support ES module environments. [[1]](diffhunk://#diff-6814bf77564b4f1c92f5861e184e28fe217c080a047fefa8b73a728f755ec45cR4) [[2]](diffhunk://#diff-6814bf77564b4f1c92f5861e184e28fe217c080a047fefa8b73a728f755ec45cL26-R32)
* Added `rollup-plugin-replace` as a development dependency in `package.json`.